### PR TITLE
Init BL, NVS error handling, Sniffer Dog freeze fix

### DIFF
--- a/ESP32C5/components/wifi_cli/wifi_cli.c
+++ b/ESP32C5/components/wifi_cli/wifi_cli.c
@@ -60,7 +60,7 @@ static esp_err_t init_wifi(void) {
     
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
-    
+
     // Register event handler only once
     if (!wifi_event_handler_registered) {
         esp_err_t reg_err = esp_event_handler_instance_register(WIFI_EVENT,
@@ -80,7 +80,19 @@ static esp_err_t init_wifi(void) {
     // AP mode will be enabled dynamically when needed (Evil Twin, etc.)
     wifi_config_t wifi_config = {0};
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
-    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+
+    // By default the WiFi driver persists STA/AP config to the NVS partition.
+    // Under a small/near-full NVS (e.g. loaded via M5Launcher's partition table)
+    // that write fails with ESP_ERR_NVS_NOT_ENOUGH_SPACE. Only in that case,
+    // fall back to RAM-only storage (we don't need to persist credentials) so
+    // boot doesn't abort. Normal builds keep flash persistence.
+    esp_err_t cfg_err = esp_wifi_set_config(WIFI_IF_STA, &wifi_config);
+    if (cfg_err == ESP_ERR_NVS_NOT_ENOUGH_SPACE) {
+        MY_LOG_INFO(TAG, "NVS full; using RAM storage for WiFi config");
+        ESP_ERROR_CHECK(esp_wifi_set_storage(WIFI_STORAGE_RAM));
+        cfg_err = esp_wifi_set_config(WIFI_IF_STA, &wifi_config);
+    }
+    ESP_ERROR_CHECK(cfg_err);
     ESP_ERROR_CHECK(esp_wifi_start());
     
     uint8_t mac[6];

--- a/ESP32C5/main/main.c
+++ b/ESP32C5/main/main.c
@@ -1971,9 +1971,19 @@ static void nvs_settings_save_dark_mode(bool enabled)
 
 static void init_backlight(void)
 {
+#if LCD_BL_IO >= 0
+    // Pancake backlight is on a GPIO (not tied to 3V3): drive it to turn the panel on.
+    gpio_config_t bk_cfg = {
+        .mode = GPIO_MODE_OUTPUT,
+        .pin_bit_mask = 1ULL << LCD_BL_IO,
+    };
+    gpio_config(&bk_cfg);
+    gpio_set_level(LCD_BL_IO, LCD_BL_ACTIVE_LEVEL);
+#else
     // No backlight GPIO configured (LED tied to 3V3).
-    // Brightness is controlled via a software overlay on lv_layer_top().
     (void)0;
+#endif
+    // Brightness levels are handled by a software overlay on lv_layer_top().
 }
 
 static void set_backlight_percent(uint8_t percent)

--- a/ESP32C5/main/main.c
+++ b/ESP32C5/main/main.c
@@ -240,6 +240,17 @@ static lv_disp_draw_buf_t draw_buf;
 static lv_color_t *buf1 = NULL;
 static lv_color_t *buf2 = NULL;
 static SemaphoreHandle_t lvgl_mutex = NULL;
+
+// Dedicated display/LVGL refresh task. Runs the LVGL loop off the main task so a
+// busy higher-priority capture task (sniffer_dog is prio 5) preempts the screen
+// refresh instead of the reverse. Stack lives in PSRAM (like the other tasks).
+#define DISPLAY_TASK_STACK    16384
+#define DISPLAY_TASK_PRIORITY 4      // must stay BELOW sniffer_dog (5)
+static TaskHandle_t display_task_handle = NULL;
+static StaticTask_t display_task_buffer;
+static StackType_t *display_task_stack = NULL;
+static void display_refresh_task(void *pvParameters);
+
 SemaphoreHandle_t sd_spi_mutex = NULL;  // Mutex for SD/SPI access (shared with display) - used by attack_handshake.c
 static SemaphoreHandle_t i2c_mutex = NULL;  // Mutex for I2C_NUM_0 (FT6336U touch + MAX17048 battery)
 static volatile bool touch_pressed_flag = false;
@@ -1920,50 +1931,57 @@ static void nvs_settings_load(void)
     wifi_scanner_set_scan_time(scan_time_min_ms, scan_time_max_ms);
 }
 
-static void nvs_settings_save_timeout(int32_t ms)
+// These settings-save helpers are called from LVGL event callbacks, which run on
+// the display task's PSRAM stack. Internal-flash (NVS) writes disable the CPU
+// cache, making a PSRAM stack unreadable mid-write -> crash. So the helpers only
+// enqueue the change; nvs_writer_task (below, created with an INTERNAL-RAM stack)
+// performs the actual commit in a safe context.
+typedef struct {
+    uint8_t kind;   // 0=timeout 1=brightness 2=scan_time 3=dark_mode
+    int32_t a;
+    int32_t b;
+} nvs_save_req_t;
+
+static QueueHandle_t nvs_save_queue = NULL;
+
+static void nvs_writer_task(void *arg)
 {
-    nvs_handle_t h;
-    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &h) == ESP_OK) {
-        nvs_set_i32(h, NVS_KEY_TIMEOUT, ms);
+    (void)arg;
+    nvs_save_req_t req;
+    for (;;) {
+        if (xQueueReceive(nvs_save_queue, &req, portMAX_DELAY) != pdTRUE) {
+            continue;
+        }
+        nvs_handle_t h;
+        if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &h) != ESP_OK) {
+            continue;
+        }
+        switch (req.kind) {
+            case 0: nvs_set_i32(h, NVS_KEY_TIMEOUT, req.a); break;
+            case 1: nvs_set_u8(h, NVS_KEY_BRIGHTNESS, (uint8_t)req.a); break;
+            case 2: nvs_set_u16(h, NVS_KEY_SCAN_MIN, (uint16_t)req.a);
+                    nvs_set_u16(h, NVS_KEY_SCAN_MAX, (uint16_t)req.b); break;
+            case 3: nvs_set_u8(h, NVS_KEY_DARK_MODE, req.a ? 1 : 0); break;
+            default: nvs_close(h); continue;
+        }
         nvs_commit(h);
         nvs_close(h);
-        ESP_LOGI(TAG, "NVS: saved timeout = %ldms", (long)ms);
+        ESP_LOGI(TAG, "NVS: committed setting kind=%u", req.kind);
     }
 }
 
-static void nvs_settings_save_brightness(uint8_t pct)
+static inline void nvs_save_enqueue(uint8_t kind, int32_t a, int32_t b)
 {
-    nvs_handle_t h;
-    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &h) == ESP_OK) {
-        nvs_set_u8(h, NVS_KEY_BRIGHTNESS, pct);
-        nvs_commit(h);
-        nvs_close(h);
-        ESP_LOGI(TAG, "NVS: saved brightness = %u%%", pct);
+    if (nvs_save_queue) {
+        nvs_save_req_t req = { kind, a, b };
+        xQueueSend(nvs_save_queue, &req, 0);   // non-blocking, safe from PSRAM stack
     }
 }
 
-static void nvs_settings_save_scan_time(uint16_t min_ms, uint16_t max_ms)
-{
-    nvs_handle_t h;
-    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &h) == ESP_OK) {
-        nvs_set_u16(h, NVS_KEY_SCAN_MIN, min_ms);
-        nvs_set_u16(h, NVS_KEY_SCAN_MAX, max_ms);
-        nvs_commit(h);
-        nvs_close(h);
-        ESP_LOGI(TAG, "NVS: saved scan time = %u-%ums", min_ms, max_ms);
-    }
-}
-
-static void nvs_settings_save_dark_mode(bool enabled)
-{
-    nvs_handle_t h;
-    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &h) == ESP_OK) {
-        nvs_set_u8(h, NVS_KEY_DARK_MODE, enabled ? 1 : 0);
-        nvs_commit(h);
-        nvs_close(h);
-        ESP_LOGI(TAG, "NVS: saved dark_mode = %d", enabled);
-    }
-}
+static void nvs_settings_save_timeout(int32_t ms)                     { nvs_save_enqueue(0, ms, 0); }
+static void nvs_settings_save_brightness(uint8_t pct)                 { nvs_save_enqueue(1, pct, 0); }
+static void nvs_settings_save_scan_time(uint16_t min_ms, uint16_t max_ms) { nvs_save_enqueue(2, min_ms, max_ms); }
+static void nvs_settings_save_dark_mode(bool enabled)                 { nvs_save_enqueue(3, enabled ? 1 : 0, 0); }
 
 // ============================================================================
 // Backlight / Brightness / Screen Dimming
@@ -3371,12 +3389,51 @@ void app_main(void)
         ESP_LOGW(TAG, "Battery ADC init failed - voltage monitor disabled");
     }
 
-    // Subscribe main task to watchdog to prevent IDLE task starvation during LVGL rendering
-    esp_task_wdt_add(NULL);
-    ESP_LOGI(TAG, "Main task subscribed to watchdog");
+    // Deferred-NVS writer: LVGL callbacks run on the display task's PSRAM stack and
+    // must not write internal flash, so settings saves are queued to this task,
+    // which uses a normal INTERNAL-RAM stack and can safely commit to NVS.
+    nvs_save_queue = xQueueCreate(8, sizeof(nvs_save_req_t));
+    if (nvs_save_queue != NULL) {
+        if (xTaskCreate(nvs_writer_task, "nvs_writer", 4096, NULL, 3, NULL) != pdPASS) {
+            ESP_LOGE(TAG, "Failed to create nvs_writer task; settings won't persist");
+        }
+    } else {
+        ESP_LOGE(TAG, "Failed to create nvs_save_queue; settings won't persist");
+    }
 
-    // ✅ Main loop diagnostics
-    ESP_LOGI(TAG, "[MAIN LOOP] Starting main event loop...");
+    // Launch the LVGL/display refresh loop as its own task with a PSRAM stack, at
+    // a priority BELOW sniffer_dog (5) so real-time capture preempts the screen
+    // refresh (not the reverse). The old code ran this loop inline in app_main at
+    // the default main-task priority (1), where a busy capture task starved it and
+    // the display froze. All LVGL access stays serialized by lvgl_mutex.
+    display_task_stack = (StackType_t *)heap_caps_malloc(DISPLAY_TASK_STACK * sizeof(StackType_t), MALLOC_CAP_SPIRAM);
+    if (display_task_stack == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate display task stack from PSRAM");
+        return;
+    }
+    display_task_handle = xTaskCreateStatic(display_refresh_task, "display", DISPLAY_TASK_STACK, NULL,
+        DISPLAY_TASK_PRIORITY, display_task_stack, &display_task_buffer);
+    if (display_task_handle == NULL) {
+        ESP_LOGE(TAG, "Failed to create display refresh task");
+        heap_caps_free(display_task_stack);
+        display_task_stack = NULL;
+        return;
+    }
+    ESP_LOGI(TAG, "Display refresh task running (PSRAM stack, prio %d)", DISPLAY_TASK_PRIORITY);
+
+    // app_main (main_task) has nothing left to do; let it return so it self-deletes.
+    return;
+}
+
+// Dedicated LVGL/display refresh loop (see notes at the display_task_* declarations).
+static void display_refresh_task(void *pvParameters)
+{
+    (void)pvParameters;
+
+    // Subscribe THIS task to the watchdog: it performs the long LVGL rendering.
+    esp_task_wdt_add(NULL);
+    ESP_LOGI(TAG, "[DISPLAY] refresh task started");
+
     uint32_t loop_counter = 0;
     TickType_t last_log = xTaskGetTickCount();
 


### PR DESCRIPTION
-Init BL

-NVS handling (needed for use via M5 Launcher)
Behavior:
     Standalone flash (healthy NVS): first esp_wifi_set_config succeeds with the default flash storage → WiFi config still persists to NVS, exactly as before.
     Via launcher (NVS full): it returns ESP_ERR_NVS_NOT_ENOUGH_SPACE, we switch to WIFI_STORAGE_RAM and retry → boots fine, no persistence (which this tool doesn't need).

-Fix Sniffer Dog Freeze Bug. Use mutex, separate screen refresh in a separate task located in PSRAM with lower priority than snifferdog.